### PR TITLE
Switch to permanent invite link

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,7 +101,7 @@
                   </li>
                   <li>
                     <a
-                      href="https://discord.gg/cnxYf3Yc"
+                      href="https://discord.gg/jw7xN2ZhJB"
                       class="icon fa-brands fa-discord alt"
                       ><span class="label">Discord</span></a
                     >


### PR DESCRIPTION
The earlier version had an in invite link to Discord which would expire in 7 days. This one never expires.