### PR TITLE
Set up redirection for all docs

### DIFF
--- a/docusaurus/CLA/index.html
+++ b/docusaurus/CLA/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/CLA" /></head></html>

--- a/docusaurus/category/query-clauses/index.html
+++ b/docusaurus/category/query-clauses/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/category/query-clauses" /></head></html>

--- a/docusaurus/client-apis/c/index.html
+++ b/docusaurus/client-apis/c/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/client-apis/c" /></head></html>

--- a/docusaurus/client-apis/cli/index.html
+++ b/docusaurus/client-apis/cli/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/client-apis/cli" /></head></html>

--- a/docusaurus/client-apis/cpp-api/index.html
+++ b/docusaurus/client-apis/cpp-api/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/client-apis/cpp-api/" /></head></html>

--- a/docusaurus/client-apis/cpp-api/udf/index.html
+++ b/docusaurus/client-apis/cpp-api/udf/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/client-apis/cpp-api/udf" /></head></html>

--- a/docusaurus/client-apis/external/NET/index.html
+++ b/docusaurus/client-apis/external/NET/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/client-apis/external/NET" /></head></html>

--- a/docusaurus/client-apis/index.html
+++ b/docusaurus/client-apis/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/client-apis/" /></head></html>

--- a/docusaurus/client-apis/java/index.html
+++ b/docusaurus/client-apis/java/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/client-apis/java" /></head></html>

--- a/docusaurus/client-apis/nodejs/index.html
+++ b/docusaurus/client-apis/nodejs/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/client-apis/nodejs" /></head></html>

--- a/docusaurus/client-apis/python/index.html
+++ b/docusaurus/client-apis/python/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/client-apis/python" /></head></html>

--- a/docusaurus/client-apis/rust/index.html
+++ b/docusaurus/client-apis/rust/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/client-apis/rust" /></head></html>

--- a/docusaurus/cypher/configuration/index.html
+++ b/docusaurus/cypher/configuration/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/configuration" /></head></html>

--- a/docusaurus/cypher/copy/index.html
+++ b/docusaurus/cypher/copy/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/copy" /></head></html>

--- a/docusaurus/cypher/data-definition/alter/index.html
+++ b/docusaurus/cypher/data-definition/alter/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/data-definition/alter" /></head></html>

--- a/docusaurus/cypher/data-definition/create-table/index.html
+++ b/docusaurus/cypher/data-definition/create-table/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/data-definition/create-table" /></head></html>

--- a/docusaurus/cypher/data-definition/drop/index.html
+++ b/docusaurus/cypher/data-definition/drop/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/data-definition/drop" /></head></html>

--- a/docusaurus/cypher/data-definition/index.html
+++ b/docusaurus/cypher/data-definition/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/data-definition/" /></head></html>

--- a/docusaurus/cypher/data-manipulation-clauses/create/index.html
+++ b/docusaurus/cypher/data-manipulation-clauses/create/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/data-manipulation-clauses/create" /></head></html>

--- a/docusaurus/cypher/data-manipulation-clauses/delete/index.html
+++ b/docusaurus/cypher/data-manipulation-clauses/delete/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/data-manipulation-clauses/delete" /></head></html>

--- a/docusaurus/cypher/data-manipulation-clauses/index.html
+++ b/docusaurus/cypher/data-manipulation-clauses/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/data-manipulation-clauses/" /></head></html>

--- a/docusaurus/cypher/data-manipulation-clauses/merge/index.html
+++ b/docusaurus/cypher/data-manipulation-clauses/merge/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/data-manipulation-clauses/merge" /></head></html>

--- a/docusaurus/cypher/data-manipulation-clauses/read-after-update/index.html
+++ b/docusaurus/cypher/data-manipulation-clauses/read-after-update/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/data-manipulation-clauses/read-after-update" /></head></html>

--- a/docusaurus/cypher/data-manipulation-clauses/set/index.html
+++ b/docusaurus/cypher/data-manipulation-clauses/set/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/data-manipulation-clauses/set" /></head></html>

--- a/docusaurus/cypher/data-types/blob/index.html
+++ b/docusaurus/cypher/data-types/blob/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/data-types/blob" /></head></html>

--- a/docusaurus/cypher/data-types/date/index.html
+++ b/docusaurus/cypher/data-types/date/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/data-types/date" /></head></html>

--- a/docusaurus/cypher/data-types/index.html
+++ b/docusaurus/cypher/data-types/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/data-types/" /></head></html>

--- a/docusaurus/cypher/data-types/interval/index.html
+++ b/docusaurus/cypher/data-types/interval/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/data-types/interval" /></head></html>

--- a/docusaurus/cypher/data-types/list/index.html
+++ b/docusaurus/cypher/data-types/list/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/data-types/list" /></head></html>

--- a/docusaurus/cypher/data-types/map/index.html
+++ b/docusaurus/cypher/data-types/map/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/data-types/map" /></head></html>

--- a/docusaurus/cypher/data-types/node/index.html
+++ b/docusaurus/cypher/data-types/node/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/data-types/node" /></head></html>

--- a/docusaurus/cypher/data-types/null/index.html
+++ b/docusaurus/cypher/data-types/null/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/data-types/null" /></head></html>

--- a/docusaurus/cypher/data-types/path/index.html
+++ b/docusaurus/cypher/data-types/path/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/data-types/path" /></head></html>

--- a/docusaurus/cypher/data-types/rel/index.html
+++ b/docusaurus/cypher/data-types/rel/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/data-types/rel" /></head></html>

--- a/docusaurus/cypher/data-types/serial/index.html
+++ b/docusaurus/cypher/data-types/serial/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/data-types/serial" /></head></html>

--- a/docusaurus/cypher/data-types/string/index.html
+++ b/docusaurus/cypher/data-types/string/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/data-types/string" /></head></html>

--- a/docusaurus/cypher/data-types/struct/index.html
+++ b/docusaurus/cypher/data-types/struct/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/data-types/struct" /></head></html>

--- a/docusaurus/cypher/data-types/timestamp/index.html
+++ b/docusaurus/cypher/data-types/timestamp/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/data-types/timestamp" /></head></html>

--- a/docusaurus/cypher/data-types/union/index.html
+++ b/docusaurus/cypher/data-types/union/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/data-types/union" /></head></html>

--- a/docusaurus/cypher/data-types/uuid/index.html
+++ b/docusaurus/cypher/data-types/uuid/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/data-types/uuid" /></head></html>

--- a/docusaurus/cypher/data-types/variant/index.html
+++ b/docusaurus/cypher/data-types/variant/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/data-types/variant" /></head></html>

--- a/docusaurus/cypher/expressions/aggregate-functions/index.html
+++ b/docusaurus/cypher/expressions/aggregate-functions/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/expressions/aggregate-functions" /></head></html>

--- a/docusaurus/cypher/expressions/blob-functions/index.html
+++ b/docusaurus/cypher/expressions/blob-functions/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/expressions/blob-functions" /></head></html>

--- a/docusaurus/cypher/expressions/case-expression/index.html
+++ b/docusaurus/cypher/expressions/case-expression/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/expressions/case-expression" /></head></html>

--- a/docusaurus/cypher/expressions/casting/index.html
+++ b/docusaurus/cypher/expressions/casting/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/expressions/casting" /></head></html>

--- a/docusaurus/cypher/expressions/comparison-operators/index.html
+++ b/docusaurus/cypher/expressions/comparison-operators/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/expressions/comparison-operators" /></head></html>

--- a/docusaurus/cypher/expressions/date-functions/index.html
+++ b/docusaurus/cypher/expressions/date-functions/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/expressions/date-functions" /></head></html>

--- a/docusaurus/cypher/expressions/index.html
+++ b/docusaurus/cypher/expressions/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/expressions/" /></head></html>

--- a/docusaurus/cypher/expressions/interval-functions/index.html
+++ b/docusaurus/cypher/expressions/interval-functions/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/expressions/interval-functions" /></head></html>

--- a/docusaurus/cypher/expressions/list-functions/index.html
+++ b/docusaurus/cypher/expressions/list-functions/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/expressions/list-functions" /></head></html>

--- a/docusaurus/cypher/expressions/logical-operators/index.html
+++ b/docusaurus/cypher/expressions/logical-operators/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/expressions/logical-operators" /></head></html>

--- a/docusaurus/cypher/expressions/map-functions/index.html
+++ b/docusaurus/cypher/expressions/map-functions/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/expressions/map-functions" /></head></html>

--- a/docusaurus/cypher/expressions/node-rel-functions/index.html
+++ b/docusaurus/cypher/expressions/node-rel-functions/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/expressions/node-rel-functions" /></head></html>

--- a/docusaurus/cypher/expressions/null-operators/index.html
+++ b/docusaurus/cypher/expressions/null-operators/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/expressions/null-operators" /></head></html>

--- a/docusaurus/cypher/expressions/numeric-functions/index.html
+++ b/docusaurus/cypher/expressions/numeric-functions/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/expressions/numeric-functions" /></head></html>

--- a/docusaurus/cypher/expressions/path_functions/index.html
+++ b/docusaurus/cypher/expressions/path_functions/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/expressions/path_functions" /></head></html>

--- a/docusaurus/cypher/expressions/pattern-matching/index.html
+++ b/docusaurus/cypher/expressions/pattern-matching/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/expressions/pattern-matching" /></head></html>

--- a/docusaurus/cypher/expressions/struct-functions/index.html
+++ b/docusaurus/cypher/expressions/struct-functions/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/expressions/struct-functions" /></head></html>

--- a/docusaurus/cypher/expressions/text-functions/index.html
+++ b/docusaurus/cypher/expressions/text-functions/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/expressions/text-functions" /></head></html>

--- a/docusaurus/cypher/expressions/timestamp-functions/index.html
+++ b/docusaurus/cypher/expressions/timestamp-functions/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/expressions/timestamp-functions" /></head></html>

--- a/docusaurus/cypher/expressions/union-functions/index.html
+++ b/docusaurus/cypher/expressions/union-functions/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/expressions/union-functions" /></head></html>

--- a/docusaurus/cypher/expressions/uuid-functions/index.html
+++ b/docusaurus/cypher/expressions/uuid-functions/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/expressions/uuid-functions" /></head></html>

--- a/docusaurus/cypher/index.html
+++ b/docusaurus/cypher/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/" /></head></html>

--- a/docusaurus/cypher/load_from/index.html
+++ b/docusaurus/cypher/load_from/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/load_from" /></head></html>

--- a/docusaurus/cypher/macro/index.html
+++ b/docusaurus/cypher/macro/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/macro" /></head></html>

--- a/docusaurus/cypher/query-clauses/call/index.html
+++ b/docusaurus/cypher/query-clauses/call/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/query-clauses/call" /></head></html>

--- a/docusaurus/cypher/query-clauses/example-database/index.html
+++ b/docusaurus/cypher/query-clauses/example-database/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/query-clauses/example-database" /></head></html>

--- a/docusaurus/cypher/query-clauses/limit/index.html
+++ b/docusaurus/cypher/query-clauses/limit/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/query-clauses/limit" /></head></html>

--- a/docusaurus/cypher/query-clauses/match/index.html
+++ b/docusaurus/cypher/query-clauses/match/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/query-clauses/match" /></head></html>

--- a/docusaurus/cypher/query-clauses/optional-match/index.html
+++ b/docusaurus/cypher/query-clauses/optional-match/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/query-clauses/optional-match" /></head></html>

--- a/docusaurus/cypher/query-clauses/order-by/index.html
+++ b/docusaurus/cypher/query-clauses/order-by/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/query-clauses/order-by" /></head></html>

--- a/docusaurus/cypher/query-clauses/return/index.html
+++ b/docusaurus/cypher/query-clauses/return/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/query-clauses/return" /></head></html>

--- a/docusaurus/cypher/query-clauses/skip/index.html
+++ b/docusaurus/cypher/query-clauses/skip/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/query-clauses/skip" /></head></html>

--- a/docusaurus/cypher/query-clauses/union/index.html
+++ b/docusaurus/cypher/query-clauses/union/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/query-clauses/union" /></head></html>

--- a/docusaurus/cypher/query-clauses/unwind/index.html
+++ b/docusaurus/cypher/query-clauses/unwind/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/query-clauses/unwind" /></head></html>

--- a/docusaurus/cypher/query-clauses/where/index.html
+++ b/docusaurus/cypher/query-clauses/where/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/query-clauses/where" /></head></html>

--- a/docusaurus/cypher/query-clauses/with/index.html
+++ b/docusaurus/cypher/query-clauses/with/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/query-clauses/with" /></head></html>

--- a/docusaurus/cypher/subquery/index.html
+++ b/docusaurus/cypher/subquery/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/subquery" /></head></html>

--- a/docusaurus/cypher/transaction/index.html
+++ b/docusaurus/cypher/transaction/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/cypher/transaction" /></head></html>

--- a/docusaurus/data-export/csv-export/index.html
+++ b/docusaurus/data-export/csv-export/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/data-export/csv-export" /></head></html>

--- a/docusaurus/data-export/index.html
+++ b/docusaurus/data-export/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/data-export/" /></head></html>

--- a/docusaurus/data-export/parquet-export/index.html
+++ b/docusaurus/data-export/parquet-export/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/data-export/parquet-export" /></head></html>

--- a/docusaurus/data-import/csv-import/index.html
+++ b/docusaurus/data-import/csv-import/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/data-import/csv-import" /></head></html>

--- a/docusaurus/data-import/index.html
+++ b/docusaurus/data-import/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/data-import/" /></head></html>

--- a/docusaurus/data-import/npy-import/index.html
+++ b/docusaurus/data-import/npy-import/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/data-import/npy-import" /></head></html>

--- a/docusaurus/data-import/parquet-import/index.html
+++ b/docusaurus/data-import/parquet-import/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/data-import/parquet-import" /></head></html>

--- a/docusaurus/development/building-kuzu/index.html
+++ b/docusaurus/development/building-kuzu/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/development/building-kuzu" /></head></html>

--- a/docusaurus/development/database-internal/datatype/index.html
+++ b/docusaurus/development/database-internal/datatype/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/development/database-internal/datatype" /></head></html>

--- a/docusaurus/development/database-internal/execution/index.html
+++ b/docusaurus/development/database-internal/execution/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/development/database-internal/execution" /></head></html>

--- a/docusaurus/development/database-internal/index.html
+++ b/docusaurus/development/database-internal/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/development/database-internal/" /></head></html>

--- a/docusaurus/development/database-internal/vector/index.html
+++ b/docusaurus/development/database-internal/vector/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/development/database-internal/vector" /></head></html>

--- a/docusaurus/development/performance-debugging/index.html
+++ b/docusaurus/development/performance-debugging/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/development/performance-debugging" /></head></html>

--- a/docusaurus/development/testing-framework/index.html
+++ b/docusaurus/development/testing-framework/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/development/testing-framework" /></head></html>

--- a/docusaurus/extensions/httpfs/index.html
+++ b/docusaurus/extensions/httpfs/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/extensions/httpfs" /></head></html>

--- a/docusaurus/extensions/index.html
+++ b/docusaurus/extensions/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/extensions/" /></head></html>

--- a/docusaurus/getting-started/c/index.html
+++ b/docusaurus/getting-started/c/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/getting-started/c" /></head></html>

--- a/docusaurus/getting-started/cli/index.html
+++ b/docusaurus/getting-started/cli/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/getting-started/cli" /></head></html>

--- a/docusaurus/getting-started/cpp/index.html
+++ b/docusaurus/getting-started/cpp/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/getting-started/cpp" /></head></html>

--- a/docusaurus/getting-started/index.html
+++ b/docusaurus/getting-started/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/getting-started/" /></head></html>

--- a/docusaurus/getting-started/java/index.html
+++ b/docusaurus/getting-started/java/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/getting-started/java" /></head></html>

--- a/docusaurus/getting-started/nodejs/index.html
+++ b/docusaurus/getting-started/nodejs/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/getting-started/nodejs" /></head></html>

--- a/docusaurus/getting-started/os/index.html
+++ b/docusaurus/getting-started/os/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/getting-started/os" /></head></html>

--- a/docusaurus/getting-started/python/index.html
+++ b/docusaurus/getting-started/python/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/getting-started/python" /></head></html>

--- a/docusaurus/getting-started/rust/index.html
+++ b/docusaurus/getting-started/rust/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/getting-started/rust" /></head></html>

--- a/docusaurus/index.html
+++ b/docusaurus/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/" /></head></html>

--- a/docusaurus/installation/index.html
+++ b/docusaurus/installation/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/installation" /></head></html>

--- a/docusaurus/kuzuexplorer/index.html
+++ b/docusaurus/kuzuexplorer/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/kuzuexplorer/" /></head></html>

--- a/docusaurus/kuzuexplorer/schema-panel/index.html
+++ b/docusaurus/kuzuexplorer/schema-panel/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/kuzuexplorer/schema-panel" /></head></html>

--- a/docusaurus/kuzuexplorer/settings-panel/index.html
+++ b/docusaurus/kuzuexplorer/settings-panel/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/kuzuexplorer/settings-panel" /></head></html>

--- a/docusaurus/kuzuexplorer/shell-panel/index.html
+++ b/docusaurus/kuzuexplorer/shell-panel/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/kuzuexplorer/shell-panel" /></head></html>

--- a/docusaurus/markdown-page/index.html
+++ b/docusaurus/markdown-page/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/markdown-page" /></head></html>

--- a/docusaurus/rdf-graphs/example-rdfgraph/index.html
+++ b/docusaurus/rdf-graphs/example-rdfgraph/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/rdf-graphs/example-rdfgraph" /></head></html>

--- a/docusaurus/rdf-graphs/index.html
+++ b/docusaurus/rdf-graphs/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/rdf-graphs/" /></head></html>

--- a/docusaurus/rdf-graphs/rdf-basics/index.html
+++ b/docusaurus/rdf-graphs/rdf-basics/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/rdf-graphs/rdf-basics" /></head></html>

--- a/docusaurus/rdf-graphs/rdf-import/index.html
+++ b/docusaurus/rdf-graphs/rdf-import/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/rdf-graphs/rdf-import" /></head></html>

--- a/docusaurus/rdf-graphs/rdfgraphs-overview/index.html
+++ b/docusaurus/rdf-graphs/rdfgraphs-overview/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/rdf-graphs/rdfgraphs-overview" /></head></html>

--- a/docusaurus/rdf-graphs/rdfgraphs-repo/index.html
+++ b/docusaurus/rdf-graphs/rdfgraphs-repo/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/rdf-graphs/rdfgraphs-repo" /></head></html>

--- a/docusaurus/search/index.html
+++ b/docusaurus/search/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=https://docs.kuzudb.com/search" /></head></html>


### PR DESCRIPTION
I figured out that we can set up redirections for all docs by referring to the sitemap. A script is written to do so as follows:

```python
import xmltodict
import os
import requests
import subprocess

XML_PATH = "https://docs.kuzudb.com/sitemap.xml"
SITE_ROOT = "https://docs.kuzudb.com"
LOCAL_HTML_ROOT = os.path.abspath("./docusaurus")
xml_data = requests.get(XML_PATH).text
xml_dict = xmltodict.parse(xml_data)

get_redirect_template = lambda url: f"""<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url={url}" /></head></html>"""

urls = xml_dict['urlset']['url']
urls = [url['loc'] for url in urls]

for url in urls:
    local_path = os.path.abspath(url.replace(SITE_ROOT, LOCAL_HTML_ROOT))
    subprocess.run(["mkdir", "-p", local_path])
    local_html_path = os.path.abspath(local_path + "/index.html")
    with open(local_html_path, "w") as f:
        f.write(get_redirect_template(url))
        print(local_html_path, '\t-->\t', url)
```

This PR updates the resulting pages.